### PR TITLE
Proper license

### DIFF
--- a/mmaplib.h
+++ b/mmaplib.h
@@ -1,9 +1,26 @@
-//
-//  mmaplib.h
-//
-//  Copyright (c) 2016 Yuji Hirose. All rights reserved.
-//  MIT License
-//
+/*
+mmaplib.h
+
+Copyright (c) 2016-2017 Yuji Hirose
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
 
 #ifndef _CPPMMAPLIB_MMAPLIB_H_
 #define _CPPMMAPLIB_MMAPLIB_H_


### PR DESCRIPTION
MIT license requires inclusion of the full license in copies of the software.
Embedding it into the header means the user doesn't have to manually go get a copy to include.

"All rights reserved" statement contradicts the license, which grants rights.