### PR TITLE
Set size_ to 0 to finish cleanup

### DIFF
--- a/mmaplib.h
+++ b/mmaplib.h
@@ -168,6 +168,7 @@ inline void MemoryMappedFile::cleanup()
         fd_ = -1;
     }
 #endif
+    size_ = 0;
 }
 
 } // namespace mmaplib


### PR DESCRIPTION
Cleanup currently doesn't reset the internal size_ member to its default value of 0.

If this library is used in an exception-free project, then std::runtime_error() doesn't do anything, and size_ is set to a garbage value by the stat structure near the end of the constructor.

Resetting the size to 0 is useful if a user wants to use a MemoryMappedFile object as an optional -> if the file is present, then we can use it, but if the path is left empty, then just give the caller an object with an invalid addr_ and size_ = 0.